### PR TITLE
fix: word spell error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const startServerAndLaunchDevtool = (entry, config, cb) => {
   Config.port = config.port || 8088;
   Config.remoteDebugPort = config.remoteDebugPort || 9222;
   Config.enableHeadless = !(config.enableHeadless === false);
-  Config.mannul = config.mannul || false;
+  Config.manual = config.manual || false;
   Devtool.start(entry, Config, cb);
 };
 


### PR DESCRIPTION
Spell error for  manual.

Pls consider if it's ok to `Object.assign(Config,config)`